### PR TITLE
Add PETSc Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           files: |
             .github/workflows/docker.yml
+            .github/workflows/Dockerfile.firedrake
+            .github/workflows/Dockerfile.petsc
 
       - name: 'Set up Docker buildx'
         id: buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
 
-      - name: 'Build container and push to GitHub Container Repository'
+      - name: 'Build PETSc container and push to GitHub Container Repository'
+        id: build-and-push
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          no-cache: true
+          file: docker/Dockerfile.petsc
+          tags: ghcr.io/mesh-adaptation/petsc-parmmg:latest
+
+      - name: 'Build Firedrake container and push to GitHub Container Repository'
         id: build-and-push
         if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker_firedrake.yml
+++ b/.github/workflows/docker_firedrake.yml
@@ -27,7 +27,7 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
-            .github/workflows/docker.yml
+            .github/workflows/docker_firedrake.yml
             .github/workflows/Dockerfile.firedrake
 
       - name: 'Set up Docker buildx'

--- a/.github/workflows/docker_firedrake.yml
+++ b/.github/workflows/docker_firedrake.yml
@@ -4,7 +4,7 @@ on:
   # Build the Docker container whenever commits are pushed to an open PR
   pull_request:
 
-  # Build the Docker container every Saturday at 1AM
+  # Build the Docker container every Saturday at 2AM
   schedule:
     - cron: '0 2 * * 6'
 

--- a/.github/workflows/docker_firedrake.yml
+++ b/.github/workflows/docker_firedrake.yml
@@ -3,7 +3,7 @@ name: 'Build bespoke Firedrake Docker container'
 on:
   # Build the Docker container if the PETSc one builds successfully
   workflow_run:
-    workflows: ['Build bespoke PETSc Docker container']
+    workflows: ['Build PETSc Docker container']
     types:
       - completed
 
@@ -14,7 +14,7 @@ on:
 jobs:
   docker:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: 'Build Docker container'
+    name: 'Build Firedrake Docker container'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out the repo'

--- a/.github/workflows/docker_firedrake.yml
+++ b/.github/workflows/docker_firedrake.yml
@@ -1,0 +1,56 @@
+name: 'Build bespoke Firedrake Docker container'
+
+on:
+  # Build the Docker container if the PETSc one builds successfully
+  workflow_run:
+    workflows: ['Build bespoke PETSc Docker container']
+    types:
+      - completed
+
+  # Build the Docker container every Saturday at 1AM
+  schedule:
+    - cron: '0 1 * * 6'
+
+jobs:
+  docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: 'Build Docker container'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out the repo'
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: 'Determine files differing from target branch'
+        if: ${{ !( github.event_name == 'schedule') }}
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            .github/workflows/docker.yml
+            .github/workflows/Dockerfile.firedrake
+
+      - name: 'Set up Docker buildx'
+        id: buildx
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: 'Log into GitHub Container Repository'
+        id: login
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: 'Build Firedrake container and push to GitHub Container Repository'
+        id: build-and-push
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          no-cache: true
+          file: docker/Dockerfile.firedrake
+          tags: ghcr.io/mesh-adaptation/firedrake-parmmg:latest

--- a/.github/workflows/docker_firedrake.yml
+++ b/.github/workflows/docker_firedrake.yml
@@ -1,19 +1,15 @@
 name: 'Build bespoke Firedrake Docker container'
 
 on:
-  # Build the Docker container if the PETSc one builds successfully
-  workflow_run:
-    workflows: ['Build PETSc Docker container']
-    types:
-      - completed
+  # Build the Docker container whenever commits are pushed to an open PR
+  pull_request:
 
   # Build the Docker container every Saturday at 1AM
   schedule:
-    - cron: '0 1 * * 6'
+    - cron: '0 2 * * 6'
 
 jobs:
   docker:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: 'Build Firedrake Docker container'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker_petsc.yml
+++ b/.github/workflows/docker_petsc.yml
@@ -23,7 +23,7 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
-            .github/workflows/docker.yml
+            .github/workflows/docker_petsc.yml
             .github/workflows/Dockerfile.petsc
 
       - name: 'Set up Docker buildx'

--- a/.github/workflows/docker_petsc.yml
+++ b/.github/workflows/docker_petsc.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docker:
-    name: 'Build Docker container'
+    name: 'Build PETSc Docker container'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out the repo'

--- a/.github/workflows/docker_petsc.yml
+++ b/.github/workflows/docker_petsc.yml
@@ -1,4 +1,4 @@
-name: 'Build bespoke Firedrake Docker container'
+name: 'Build bespoke PETSc Docker container'
 
 on:
   # Build the Docker container whenever commits are pushed to an open PR
@@ -24,7 +24,6 @@ jobs:
         with:
           files: |
             .github/workflows/docker.yml
-            .github/workflows/Dockerfile.firedrake
             .github/workflows/Dockerfile.petsc
 
       - name: 'Set up Docker buildx'
@@ -51,13 +50,3 @@ jobs:
           no-cache: true
           file: docker/Dockerfile.petsc
           tags: ghcr.io/mesh-adaptation/petsc-parmmg:latest
-
-      - name: 'Build Firedrake container and push to GitHub Container Repository'
-        id: build-and-push
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          no-cache: true
-          file: docker/Dockerfile.firedrake
-          tags: ghcr.io/mesh-adaptation/firedrake-parmmg:latest

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -1,29 +1,30 @@
-FROM firedrakeproject/firedrake-vanilla
+FROM ghcr.io/mesh-adaptation/petsc-parmmg
 
 USER firedrake
 WORKDIR /home/firedrake
 
-# Reconfigure PETSc with packages required for mesh adaptation and rebuild
-RUN bash -c "cd petsc && \
-	  git fetch && \
-	  cp default/lib/petsc/conf/reconfigure-default.py . && \
-	  sed -i 's/]/]\n  configure_options.extend(sys.argv[1:])/g' reconfigure-default.py && \
-	  ./reconfigure-default.py $(echo -n $(curl https://raw.githubusercontent.com/mesh-adaptation/mesh-adaptation-docs/main/install/petsc_reconfigure_options.txt)) && \
-    make all"
+ENV PETSC_ARCH default
 
-# Rebuild Firedrake and install additional packages
-RUN bash -c "source firedrake/bin/activate && \
-	  cd firedrake/src/firedrake && \
-	  firedrake-update --install thetis && \
-	  cd .. && \
+# Build Firedrake and install additional packages
+RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
+RUN bash -c "python3 firedrake-install \
+    --no-package-manager \
+    --disable-ssh \
+    --torch \
+    --honour-petsc-dir \
+    --mpicc=${MPICH_DIR}/mpicc \
+    --mpicxx=${MPICH_DIR}/mpicxx \
+    --mpif90=${MPICH_DIR}/mpif90 \
+    --mpiexec=${MPICH_DIR}/mpiexec \
+    --install thetis && \
+    source firedrake/bin/activate && \
+	  cd firedrake/src && \
 	  git clone https://github.com/mesh-adaptation/animate.git && \
+	  git clone https://github.com/mesh-adaptation/movement.git && \
+	  git clone https://github.com/mesh-adaptation/goalie.git && \
 	  cd animate && \
 	  make install && \
-	  cd .. && \
-	  git clone https://github.com/mesh-adaptation/movement.git && \
-	  cd movement && \
+	  cd ../movement && \
 	  make install && \
-	  cd .. && \
-	  git clone https://github.com/mesh-adaptation/goalie.git && \
-	  cd goalie && \
+	  cd ../goalie && \
 	  make install"

--- a/docker/Dockerfile.petsc
+++ b/docker/Dockerfile.petsc
@@ -35,7 +35,8 @@ WORKDIR /home/firedrake
 RUN git clone https://github.com/firedrakeproject/petsc.git
 
 # Build MPICH manually because we don't want PETSc to build it twice
-RUN bash -c 'cd petsc; \
+RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
+    cd petsc; \
     ./configure \
         --COPTFLAGS=-O3 -march=native -mtune=native \
         --CXXOPTFLAGS=-O3 -march=native -mtune=native \
@@ -64,8 +65,8 @@ RUN bash -c 'cd petsc; \
         --download-scalapack \
         --download-suitesparse \
         --download-superlu_dist \
-        PETSC_ARCH=packages; \
-        mv packages/include/petscconf.h packages/include/old_petscconf.nope;'
+        PETSC_ARCH=${PACKAGES}; \
+        mv ${PACKAGES}/include/petscconf.h ${PACKAGES}/include/old_petscconf.nope;'
 # Don't run make here, we only want MPICH and HWLOC
 # It is also necessary to move `petscconf.h` so packages isn't treated like a working PETSc
 

--- a/docker/Dockerfile.petsc
+++ b/docker/Dockerfile.petsc
@@ -102,7 +102,8 @@ RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
         --with-suitesparse-dir=${PACKAGES} \
         --with-superlu_dist-dir=${PACKAGES} \
         PETSC_ARCH=default; \
-    make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all;'
+    make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all; \
+    mv ${PACKAGES}/eigen3/Eigen ${PACKAGES}'
 
 # Clean up unnecessary files
 RUN rm -rf /home/firedrake/petsc/**/externalpackages \

--- a/docker/Dockerfile.petsc
+++ b/docker/Dockerfile.petsc
@@ -103,7 +103,7 @@ RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
         --with-superlu_dist-dir=${PACKAGES} \
         PETSC_ARCH=default; \
     make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all; \
-    mv ${PACKAGES}/eigen3/Eigen ${PACKAGES}'
+    mv ${PACKAGES}/include/eigen3/Eigen ${PACKAGES}/include'
 
 # Clean up unnecessary files
 RUN rm -rf /home/firedrake/petsc/**/externalpackages \

--- a/docker/Dockerfile.petsc
+++ b/docker/Dockerfile.petsc
@@ -65,7 +65,7 @@ RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
         --download-scalapack \
         --download-suitesparse \
         --download-superlu_dist \
-        PETSC_ARCH=${PACKAGES}; \
+        PETSC_ARCH=packages; \
         mv ${PACKAGES}/include/petscconf.h ${PACKAGES}/include/old_petscconf.nope;'
 # Don't run make here, we only want MPICH and HWLOC
 # It is also necessary to move `petscconf.h` so packages isn't treated like a working PETSc

--- a/docker/Dockerfile.petsc
+++ b/docker/Dockerfile.petsc
@@ -1,0 +1,119 @@
+# DockerFile for an environment into which firedrake can be installed. Based off
+# https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.env
+
+FROM ubuntu:24.04
+
+# Update and install required packages for Firedrake
+USER root
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+    && apt-get -y dist-upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata \
+    && apt-get -y install curl vim docker.io openssh-client build-essential autoconf automake \
+        cmake gfortran git libopenblas-serial-dev libtool python3-dev python3-pip python3-tk \
+        python3-venv python3-requests zlib1g-dev libboost-dev sudo gmsh bison flex ninja-build \
+        libocct-ocaf-dev libocct-data-exchange-dev swig graphviz libcurl4-openssl-dev libxml2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Use a more sane locale
+ENV LC_ALL C.UTF-8
+
+# Change the `ubuntu` user to `firedrake`
+# and ensure that we do not run as root on self-hosted systems
+RUN usermod -d /home/firedrake -m ubuntu \
+    && usermod -l firedrake ubuntu \
+    && groupmod -n firedrake ubuntu \
+    && usermod -aG sudo firedrake \
+    && echo "firedrake:docker" | chpasswd \
+    && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers \
+    && ldconfig
+
+USER firedrake
+WORKDIR /home/firedrake
+
+# Fetch PETSc
+RUN git clone https://github.com/firedrakeproject/petsc.git
+
+# Build MPICH manually because we don't want PETSc to build it twice
+RUN bash -c 'cd petsc; \
+    ./configure \
+        --COPTFLAGS=-O3 -march=native -mtune=native \
+        --CXXOPTFLAGS=-O3 -march=native -mtune=native \
+        --FOPTFLAGS=-O3 -march=native -mtune=native \
+        --with-c2html=0 \
+        --with-debugging=0 \
+        --with-fortran-bindings=0 \
+        --with-make-np=12 \
+        --with-shared-libraries=1 \
+        --with-zlib \
+        --download-eigen \
+        --download-fftw \
+        --download-hdf5 \
+        --download-hwloc \
+        --download-hypre \
+        --download-metis \
+        --download-mmg \
+        --download-mumps \
+        --download-mpich \
+        --download-mpich-device=ch3:sock \
+        --download-netcdf \
+        --download-parmmg \
+        --download-pastix \
+        --download-pnetcdf \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu_dist \
+        PETSC_ARCH=packages; \
+        mv packages/include/petscconf.h packages/include/old_petscconf.nope;'
+# Don't run make here, we only want MPICH and HWLOC
+# It is also necessary to move `petscconf.h` so packages isn't treated like a working PETSc
+
+# Build PETSc
+RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
+    cd petsc; \
+    ./configure \
+        --COPTFLAGS=-O3 -march=native -mtune=native \
+        --CXXOPTFLAGS=-O3 -march=native -mtune=native \
+        --FOPTFLAGS=-O3 -march=native -mtune=native \
+        --with-c2html=0 \
+        --with-debugging=0 \
+        --with-fortran-bindings=0 \
+        --with-make-np=12 \
+        --with-shared-libraries=1 \
+        --with-bison \
+        --with-flex \
+        --with-zlib \
+        --with-eigen-dir=${PACKAGES} \
+        --with-fftw-dir=${PACKAGES} \
+        --with-hdf5-dir=${PACKAGES} \
+        --with-hwloc-dir=${PACKAGES} \
+        --with-hypre-dir=${PACKAGES} \
+        --with-metis-dir=${PACKAGES} \
+        --with-mmg-dir=${PACKAGES} \
+        --with-mpi-dir=${PACKAGES} \
+        --with-mumps-dir=${PACKAGES} \
+        --with-netcdf-dir=${PACKAGES} \
+        --with-parmmg-dir=${PACKAGES} \
+        --with-pastix-dir=${PACKAGES} \
+        --with-pnetcdf-dir=${PACKAGES} \
+        --with-ptscotch-dir=${PACKAGES} \
+        --with-scalapack-dir=${PACKAGES} \
+        --with-suitesparse-dir=${PACKAGES} \
+        --with-superlu_dist-dir=${PACKAGES} \
+        PETSC_ARCH=default; \
+    make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all;'
+
+# Clean up unnecessary files
+RUN rm -rf /home/firedrake/petsc/**/externalpackages \
+    && rm -rf /home/firedrake/petsc/src/docs \
+    && rm -f /home/firedrake/petsc/src/**/tutorials/output/* \
+    && rm -f /home/firedrake/petsc/src/**/tests/output/*
+
+# Set some useful environment variables
+ENV PETSC_DIR /home/firedrake/petsc
+ENV MPICH_DIR /home/firedrake/petsc/packages/bin
+ENV HDF5_DIR /home/firedrake/petsc/packages
+ENV HDF5_MPI ON
+ENV OMP_NUM_THREADS 1
+ENV OPENBLAS_NUM_THREADS 1

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,16 +2,14 @@ all: build
 
 DOCKERHUB	= YES
 
-ifeq ($(DOCKERHUB),YES)
-NAMESPACE	= jwallwork
-else
+# PACKAGE		= petsc
+PACKAGE		= firedrake
 NAMESPACE	= ghcr.io/mesh-adaptation
-endif
-IMAGE		= firedrake-parmmg
+IMAGE		= $(PACKAGE)-parmmg
 TAG		= latest
 
 build:
-	docker build -f Dockerfile.firedrake -t $(NAMESPACE)/$(IMAGE):$(TAG) --no-cache .
+	docker build -f Dockerfile.$(PACKAGE) -t $(NAMESPACE)/$(IMAGE):$(TAG) .
 
 pull:
 	docker pull $(NAMESPACE)/$(IMAGE):$(TAG)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,8 +2,7 @@ all: build
 
 DOCKERHUB	= YES
 
-# PACKAGE		= petsc
-PACKAGE		= firedrake
+PACKAGE		?=
 NAMESPACE	= ghcr.io/mesh-adaptation
 IMAGE		= $(PACKAGE)-parmmg
 TAG		= latest

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,5 @@
 all: build
 
-DOCKERHUB	= YES
-
 PACKAGE		?=
 NAMESPACE	= ghcr.io/mesh-adaptation
 IMAGE		= $(PACKAGE)-parmmg

--- a/install/petsc_reconfigure_options.txt
+++ b/install/petsc_reconfigure_options.txt
@@ -1,3 +1,0 @@
---download-eigen
---download-mmg
---download-parmmg


### PR DESCRIPTION
Closes #39.

Rather than reconfiguring and rebuilding Firedrake's PETSc build, if we just build it ourselves then we can more easily handle external packages and have more control.

I *think* this PR includes a fix for the Eigen linking issue but let's see. (Internet isn't good enough to check by installing locally.)