### PR TITLE
#45: Add reusable workflows

### DIFF
--- a/.github/workflows/reusable_citation_check.yml
+++ b/.github/workflows/reusable_citation_check.yml
@@ -2,11 +2,6 @@ name: 'Reusable Citation Check'
 
 on:
   workflow_call:
-    inputs:
-      python-version:
-        required: false
-        type: string
-        default: '3.8'
 
 jobs:
   citation_check:
@@ -20,7 +15,7 @@ jobs:
       - name: 'Setup Python'
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: '3.8'
 
       - name: 'Check citation'
         run: |

--- a/.github/workflows/reusable_citation_check.yml
+++ b/.github/workflows/reusable_citation_check.yml
@@ -17,7 +17,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: 'Check citation'
+      - name: 'Install cffconvert'
         run: |
           pip install cffconvert
-          make check_citation
+
+      - name: 'Check citation formatting'
+        run: |
+          echo "Checking CITATION.cff formatting..."
+          cffconvert --validate
+          echo "PASS"

--- a/.github/workflows/reusable_citation_check.yml
+++ b/.github/workflows/reusable_citation_check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Setup Python'
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: 'Check citation'
         run: |

--- a/.github/workflows/reusable_citation_check.yml
+++ b/.github/workflows/reusable_citation_check.yml
@@ -1,0 +1,28 @@
+name: 'Reusable Citation Check'
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        type: string
+        default: '3.8'
+
+jobs:
+  citation_check:
+    name: 'Check Citation'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Check out the repo'
+        uses: actions/checkout@v4
+
+      - name: 'Setup Python'
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: 'Check citation'
+        run: |
+          pip install cffconvert
+          make check_citation

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_suite:
     name: 'Test suite'

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: 'Install Package'
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -1,0 +1,69 @@
+name: 'Reusable Test Suite'
+
+on:
+  workflow_call:
+    inputs:
+      install-command:
+        description: 'Command to install the package'
+        required: true
+        type: string
+      test-command:
+        description: 'Command to run the tests'
+        required: true
+        type: string
+      changed-files-patterns:
+        description: 'File patterns to check for changes'
+        required: true
+        type: string
+
+jobs:
+  test_suite:
+    name: 'Test suite'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+      options: --user root
+
+    steps:
+      - name: 'Check out the repo'
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: 'Determine files differing from target branch'
+        id: changed-files
+        if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/main' }}
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            .github/workflows/test_suite.yml
+            ${{ inputs.changed-files-patterns }}
+
+      - name: 'Cleanup'
+        if: ${{ always() }}
+        run: |
+          cd ..
+          rm -rf build
+
+      - name: 'Setup Python'
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: 'Install Package'
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          ${{ inputs.install-command }}
+
+      - name: 'Lint'
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          make lint
+
+      - name: 'Run Tests'
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          ${{ inputs.test-command }}


### PR DESCRIPTION
Closes #45.

After this is merged I will change `citation_check.yml` in Animate/Goalie/Movement to be:
```
name: 'Citation Check'

on:
  push:
    branches:
      - main
    paths:
      - '**/*.cff'

  pull_request:
    paths:
      - '**/*.cff'

  workflow_dispatch:

jobs:
  citation_check:
    uses: mesh-adaptation/mesh-adaptation-docs/.github/workflows/citation_check.yml@main
```

and `test_suite.yml` in Animate will be:
```
name: 'Run Animate Test Suite'

on:
  push:
    branches:
      - main
  pull_request:
  schedule:
    - cron: '0 1 * * 0'

jobs:
  test_suite:
    uses: mesh-adaptation/mesh-adaptation-docs/.github/workflows/test_suite.yml@main
    with:
      install-command: 'python -m pip uninstall -y animate && python -m pip install -e .'
      test-command: |
        export GITHUB_ACTIONS_TEST_RUN=1
        python $(which firedrake-clean)
        export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints
        python -m coverage erase
        python -m coverage run --source=animate -m pytest -v --durations=20 test
        python -m coverage report
      changed-files-patterns: |
        **/*.py
        **/*.cxx
```

and similarly for Goalie and Movement.