### PR TITLE
Add UM2N API documentation to webpage

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,7 @@ PYTHON        = ${VIRTUAL_ENV}/bin/python3
 ANIMATE       = ${VIRTUAL_ENV}/src/animate
 MOVEMENT      = ${VIRTUAL_ENV}/src/movement
 GOALIE        = ${VIRTUAL_ENV}/src/goalie
+UM2N          = ${VIRTUAL_ENV}/src/UM2N
 
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -64,6 +65,7 @@ copy_demos:
 	install -d $(BUILDDIR)/html/animate
 	install -d $(BUILDDIR)/html/goalie
 	install -d $(BUILDDIR)/html/movement
+	install -d $(BUILDDIR)/html/UM2N
 	mkdir -p $(BUILDDIR)/html/_images
 	cp source/animate/images/*.jpg $(BUILDDIR)/html/_images
 	cp source/goalie/images/*.jpg $(BUILDDIR)/html/_images
@@ -85,6 +87,7 @@ apidoc:
 	$(SPHINXAPIDOC) $$(python3 -c "import animate; import os; print(os.path.dirname(animate.__file__))") -o source -f -T
 	$(SPHINXAPIDOC) $$(python3 -c "import goalie; import os; print(os.path.dirname(goalie.__file__))") -o source -f -T
 	$(SPHINXAPIDOC) $$(python3 -c "import movement; import os; print(os.path.dirname(movement.__file__))") -o source -f -T
+	$(SPHINXAPIDOC) $$(python3 -c "import UM2N; import os; print(os.path.dirname(UM2N.__file__))") -o source -f -T
 
 clean:
 	-git clean -fdx $(BUILDDIR)/html/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,8 @@ extensions = [
     "sphinx.ext.autosectionlabel",
 ]
 
+autodoc_mock_imports = ["torch", "torch_geometric", "pytorch3d"]
+
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = "Animate, Movement and Goalie"
+project = "Animate, Movement, Goalie and UM2N"
 copyright = f"2021-{datetime.datetime.now().year}, Joseph G. Wallwork et al."
 author = "Joseph G. Wallwork et al."
 
@@ -71,6 +71,7 @@ author = "Joseph G. Wallwork et al."
 import animate
 import movement
 import goalie
+import UM2N
 
 version = "0.1"
 # The full version, including alpha/beta/rc tags.
@@ -127,7 +128,7 @@ html_context = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "Goaliedoc"
+htmlhelp_basename = "meshadaptdoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -153,8 +154,8 @@ latex_elements = {
 latex_documents = [
     (
         master_doc,
-        "Animate_Goalie.tex",
-        "Documentation for Animate, Movement and Goalie",
+        "mesh-adaptation.tex",
+        "Documentation for Animate, Movement, Goalie and UM2N",
         "Joseph G. Wallwork et al.",
         "manual",
     ),
@@ -168,7 +169,8 @@ latex_documents = [
 man_pages = [
     (master_doc, "Animate", "Animate documentation", [author], 1),
     (master_doc, "Movement", "Movement documentation", [author], 1),
-    (master_doc, "goalie", "Goalie documentation", [author], 1),
+    (master_doc, "Goalie", "Goalie documentation", [author], 1),
+    (master_doc, "UM2N", "UM2N documentation", [author], 1),
 ]
 
 
@@ -180,11 +182,11 @@ man_pages = [
 texinfo_documents = [
     (
         master_doc,
-        "Animate, Movement and Goalie",
-        "Documentation for Animate, Movement and Goalie",
+        "Animate, Movement, Goalie and UM2N",
+        "Documentation for Animate, Movement, Goalie and UM2N",
         author,
-        "Animate, Movement and Goalie",
-        "Animate, Movement and Goalie Mesh Adaptation Toolkits",
+        "Animate, Movement, Goalie and UM2N",
+        "Animate, Movement, Goalie and UM2N Mesh Adaptation Toolkits",
         "Miscellaneous",
     ),
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
-.. title:: Animate, Movement and Goalie
+.. title:: Animate, Movement, Goalie and UM2N
 
 .. only:: html
 
-Welcome to the documentation for Animate, Movement and Goalie!
-==============================================================
+Welcome to the documentation for Animate, Movement, Goalie and UM2N!
+====================================================================
 
 `Animate <animate/index.html>`__ is a package which provides anisotropic mesh adaptation
 functionality for the Python-based finite element library
@@ -30,7 +30,8 @@ and the metric-based approach. Goalie uses a 'fixed-point iteration' approach,
 meaning that the PDE (and its adjoint) is solved over the whole space-time domain
 whenever mesh adaptation is applied.
 
-`UM2N <UM2N/index.html>`__
+`UM2N <UM2N/index.html>`__ is an end-to-end machine-learning based implementation of
+mesh movement.
 
 .. rubric:: Mathematical background
 
@@ -42,12 +43,14 @@ contains some
 `excellent documentation <http://www.dolfin-adjoint.org/en/latest/documentation/maths/index.html>`__
 on the mathematical background of adjoint problems. The metric-based mesh adaptation,
 mesh movement, and goal-oriented error estimation functionalities provided by
-`Animate <animate/index.html>`__, `Movement <movement/index.html>`__ and
-`Goalie <goalie/index.html>`__ are described in the respective manuals.
+`Animate <animate/index.html>`__, `Movement <movement/index.html>`__,
+`Goalie <goalie/index.html>`__ and `UM2N <UM2N/index.html>`__ are described in the
+respective manuals.
 
 .. rubric:: Source code
 
-The source codes for all three packages are hosted on GitHub:
+The source codes for all four packages are hosted on GitHub:
 `Animate <https://github.com/mesh-adaptation/animate/>`__,
 `Movement <https://github.com/mesh-adaptation/movement/>`__,
 `Goalie <https://github.com/mesh-adaptation/goalie/>`__.
+`UM2N <https://github.com/mesh-adaptation/UM2N/>`__.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,8 @@ and the metric-based approach. Goalie uses a 'fixed-point iteration' approach,
 meaning that the PDE (and its adjoint) is solved over the whole space-time domain
 whenever mesh adaptation is applied.
 
+`UM2N <UM2N/index.html>`__
+
 .. rubric:: Mathematical background
 
 We refer to the


### PR DESCRIPTION
Closes https://github.com/mesh-adaptation/UM2N/issues/12.

This PR adds UM2N to the mesh-adaptation webpage repo so that users will be able to view the API documentation once the webpage gets updated.