### PR TITLE
Update when Docker build and push are triggered

### DIFF
--- a/.github/workflows/docker_firedrake-parmmg.yml
+++ b/.github/workflows/docker_firedrake-parmmg.yml
@@ -4,6 +4,8 @@ on:
   # Check that Docker build succeeds when these files get changed in an open PR
   pull_request:
     paths:
+      - '.github/workflows/docker_petsc-parmmg.yml'
+      - 'docker/Dockerfile.petsc'
       - '.github/workflows/docker_firedrake-parmmg.yml'
       - 'docker/Dockerfile.firedrake'
 
@@ -12,6 +14,8 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/docker_petsc-parmmg.yml'
+      - 'docker/Dockerfile.petsc'
       - '.github/workflows/docker_firedrake-parmmg.yml'
       - 'docker/Dockerfile.firedrake'
 

--- a/.github/workflows/docker_firedrake-parmmg.yml
+++ b/.github/workflows/docker_firedrake-parmmg.yml
@@ -4,8 +4,6 @@ on:
   # Check that Docker build succeeds when these files get changed in an open PR
   pull_request:
     paths:
-      - '.github/workflows/docker_petsc-parmmg.yml'
-      - 'docker/Dockerfile.petsc'
       - '.github/workflows/docker_firedrake-parmmg.yml'
       - 'docker/Dockerfile.firedrake'
 
@@ -14,10 +12,14 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/docker_petsc-parmmg.yml'
-      - 'docker/Dockerfile.petsc'
       - '.github/workflows/docker_firedrake-parmmg.yml'
       - 'docker/Dockerfile.firedrake'
+
+  # Trigger this workflow when docker_petsc-parmmg.yml completes successfully
+  workflow_run:
+    workflows: ['Build bespoke PETSc Docker container']
+    types:
+      - completed
 
   # Build and push the Docker container every Saturday at 2AM
   schedule:

--- a/.github/workflows/docker_firedrake-parmmg.yml
+++ b/.github/workflows/docker_firedrake-parmmg.yml
@@ -1,10 +1,21 @@
 name: 'Build bespoke Firedrake Docker container'
 
 on:
-  # Build the Docker container whenever commits are pushed to an open PR
+  # Check that Docker build succeeds when these files get changed in an open PR
   pull_request:
+    paths:
+      - '.github/workflows/docker_firedrake-parmmg.yml'
+      - 'docker/Dockerfile.firedrake'
 
-  # Build the Docker container every Saturday at 2AM
+  # Build and push the Docker container when these files get changed on the main branch
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker_firedrake-parmmg.yml'
+      - 'docker/Dockerfile.firedrake'
+
+  # Build and push the Docker container every Saturday at 2AM
   schedule:
     - cron: '0 2 * * 6'
 
@@ -14,6 +25,3 @@ jobs:
     with:
       dockerfile-path: 'docker/Dockerfile.firedrake'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
-      changed-files: |
-        .github/workflows/docker_firedrake-parmmg.yml
-        docker/Dockerfile.firedrake

--- a/.github/workflows/docker_firedrake-parmmg.yml
+++ b/.github/workflows/docker_firedrake-parmmg.yml
@@ -15,15 +15,11 @@ on:
       - '.github/workflows/docker_firedrake-parmmg.yml'
       - 'docker/Dockerfile.firedrake'
 
-  # Trigger this workflow when docker_petsc-parmmg.yml completes successfully
+  # Trigger this workflow when docker_petsc-parmmg.yml completes on the main branch
   workflow_run:
     workflows: ['Build bespoke PETSc Docker container']
     types:
       - completed
-
-  # Build and push the Docker container every Saturday at 2AM
-  schedule:
-    - cron: '0 2 * * 6'
 
 jobs:
   docker:

--- a/.github/workflows/docker_petsc-parmmg.yml
+++ b/.github/workflows/docker_petsc-parmmg.yml
@@ -1,10 +1,18 @@
 name: 'Build bespoke PETSc Docker container'
 
 on:
-  # Build the Docker container whenever commits are pushed to an open PR
   pull_request:
+    paths:
+      - '.github/workflows/docker_petsc-parmmg.yml'
+      - 'docker/Dockerfile.petsc'
 
-  # Build the Docker container every Saturday at 1AM
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker_petsc-parmmg.yml'
+      - 'docker/Dockerfile.petsc'
+
   schedule:
     - cron: '0 1 * * 6'
 
@@ -14,6 +22,3 @@ jobs:
     with:
       dockerfile-path: 'docker/Dockerfile.petsc'
       docker-image-tag: 'ghcr.io/mesh-adaptation/petsc-parmmg:latest'
-      changed-files: |
-        .github/workflows/docker_petsc-parmmg.yml
-        docker/Dockerfile.petsc

--- a/.github/workflows/docker_petsc-parmmg.yml
+++ b/.github/workflows/docker_petsc-parmmg.yml
@@ -1,11 +1,13 @@
 name: 'Build bespoke PETSc Docker container'
 
 on:
+  # Check that Docker build succeeds when these files get changed in an open PR
   pull_request:
     paths:
       - '.github/workflows/docker_petsc-parmmg.yml'
       - 'docker/Dockerfile.petsc'
 
+  # Build and push the Docker container when these files get changed on the main branch
   push:
     branches:
       - main
@@ -13,6 +15,7 @@ on:
       - '.github/workflows/docker_petsc-parmmg.yml'
       - 'docker/Dockerfile.petsc'
 
+  # Build and push the Docker container every Saturday at 1AM
   schedule:
     - cron: '0 1 * * 6'
 

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -11,10 +11,6 @@ on:
         description: 'Tag for the Docker image to push'
         required: true
         type: string
-      changed-files:
-        description: 'Files to check for changes'
-        required: true
-        type: string
 
 jobs:
   docker:
@@ -23,25 +19,12 @@ jobs:
 
     steps:
       - name: 'Check out the repo'
-        id: checkout
         uses: actions/checkout@v4
 
-      - name: 'Determine files differing from target branch'
-        if: ${{ github.event_name != 'schedule' }}
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            ${{ inputs.changed-files }}
-
       - name: 'Set up Docker buildx'
-        id: buildx
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'schedule' }}
         uses: docker/setup-buildx-action@v3
 
       - name: 'Log into GitHub Container Repository'
-        id: login
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'schedule' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -50,8 +33,6 @@ jobs:
           logout: true
 
       - name: 'Build and Push Docker Container'
-        id: build-and-push
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'schedule' }}
         uses: docker/build-push-action@v5
         with:
           push: true

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build and Push Docker Container'
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
           tags: ${{ inputs.docker-image-tag }}


### PR DESCRIPTION
Closes #55. Closes #56.

I also replaced using `changed-files` with the inbuilt `paths` syntax. I think `changed-files` is great when we want some fine-grained control, but I think it is an overkill when we just use it to control workflow triggering. 

With this PR, the following triggers `docker_petsc-parmmg.yml` to run:
1. `.github/workflows/docker_petsc-parmmg.yml` or `docker/Dockerfile.petsc` change in a PR (doesn't push to ghcr)
2. `.github/workflows/docker_petsc-parmmg.yml` or `docker/Dockerfile.petsc` change on the main branch (pushes to ghcr)
3.  Scheduled at 1AM every Saturday

and the following triggers `docker_firedrake-parmmg.yml` to run:
1. `.github/workflows/docker_firedrake-parmmg.yml` or `docker/Dockerfile.firedrake` change in a PR (doesn't push to ghcr)
2. `.github/workflows/docker_firedrake-parmmg.yml` or `docker/Dockerfile.firedrake` change on the main branch (pushes to ghcr)
3. After `docker_petsc-parmmg.yml` completes on the main branch, i.e.
    - After `.github/workflows/docker_petsc-parmmg.yml` or `docker/Dockerfile.petsc` change on the main branch (and the PETSc image is pushed to ghcr)
    - After the scheduled event 