### PR TITLE
Link burgers goal-oriented demo to docs

### DIFF
--- a/docs/source/goalie/index.rst
+++ b/docs/source/goalie/index.rst
@@ -57,3 +57,4 @@ be searched using the inbuilt :ref:`search engine <search>`.
     Hessian-based mesh adaptation for a 2D steady-state problem <../demos/point_discharge2d-hessian.py>
     Goal-oriented mesh adaptation for a 2D steady-state problem <../demos/point_discharge2d-goal_oriented.py>
     Hessian-based mesh adaptation for a 2D time-dependent problem <../demos/burgers-hessian.py>
+    Goal-oriented mesh adaptation for a 2D time-dependent problem <../demos/burgers-goal_oriented.py>


### PR DESCRIPTION
Linked to https://github.com/mesh-adaptation/goalie/pull/112 and https://github.com/mesh-adaptation/goalie/issues/28

Adds unsteady, goal-oriented demo from Goalie to documentation.