### PR TITLE
Allow switching Docker image in reusable test workflow

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -15,6 +15,11 @@ on:
         description: 'File patterns to check for changes'
         required: true
         type: string
+      docker-image:
+        description: 'Name of the Firedrake Docker image to use'
+        required: false
+        default: 'firedrake-parmmg'
+        type: string
 
 # Cancel jobs running if new commits are pushed
 concurrency:
@@ -26,7 +31,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
       options: --user root
 
     steps:


### PR DESCRIPTION
Closes #66.

Required for the completion of https://github.com/mesh-adaptation/UM2N/pull/59.

Note that the option defaults to `firedrake-parmmg` so that we only need to provide this for the UM2N test suite.